### PR TITLE
Remove deprecated config_entry init

### DIFF
--- a/custom_components/ha_ecowitt_iot/config_flow.py
+++ b/custom_components/ha_ecowitt_iot/config_flow.py
@@ -58,15 +58,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     @staticmethod
     def async_get_options_flow(config_entry):
         """Get the options flow for this handler."""
-        return OptionsFlowHandler(config_entry)
+        return OptionsFlowHandler()
 
 
 class OptionsFlowHandler(config_entries.OptionsFlow):
     """Handle options flow for Ecowitt integration."""
-
-    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
-        """Initialize options flow."""
-        self.config_entry = config_entry
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None


### PR DESCRIPTION
As per the blog post [here](https://developers.home-assistant.io/blog/2024/11/12/options-flow) passing config_entry is now deprecated and will be removed in 2025.12.

This PR removes this, as there is no need to pass it.

Fixes https://github.com/Ecowitt/ha-ecowitt-iot/issues/22