### PR TITLE
Fix battery sensors: proper device_class and numeric values

### DIFF
--- a/custom_components/ha_ecowitt_iot/sensor.py
+++ b/custom_components/ha_ecowitt_iot/sensor.py
@@ -416,6 +416,9 @@ SENSOR_DESCRIPTIONS = (
         key="con_batt",
         translation_key="con_batt",
         icon="mdi:battery",
+        device_class=SensorDeviceClass.BATTERY,
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     SensorEntityDescription(
@@ -440,6 +443,9 @@ SENSOR_DESCRIPTIONS = (
         key="piezora_batt",
         translation_key="piezora_batt",
         icon="mdi:battery",
+        device_class=SensorDeviceClass.BATTERY,
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     # SensorEntityDescription(
@@ -518,6 +524,9 @@ ECOWITT_SENSORS_MAPPING: Final = {
     WittiotDataTypes.BATTERY: SensorEntityDescription(
         key="BATTERY",
         icon="mdi:battery",
+        device_class=SensorDeviceClass.BATTERY,
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     WittiotDataTypes.DISTANCE: SensorEntityDescription(
@@ -546,7 +555,7 @@ ECOWITT_SENSORS_MAPPING: Final = {
     WittiotDataTypes.RSSI: SensorEntityDescription(
         key="RSSI",
         state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT, 
+        native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:wifi",
     ),
@@ -765,8 +774,20 @@ class MainDevEcowittSensor(
 
     @property
     def native_value(self) -> str | int | float | None:
-        """Return the state."""
-        return self.coordinator.data.get(self.entity_description.key)
+        value = self.coordinator.data.get(self.entity_description.key)
+
+        # converting battery percentage string to integer
+        if (
+            self.entity_description.device_class == SensorDeviceClass.BATTERY
+            and isinstance(value, str)
+            and value.endswith("%")
+        ):
+            try:
+                return int(value[:-1])
+            except ValueError:
+                return None
+
+        return value
 
 
 class SubDevEcowittSensor(
@@ -807,7 +828,20 @@ class SubDevEcowittSensor(
     @property
     def native_value(self) -> str | int | float | None:
         """Return the state."""
-        return self.coordinator.data.get(self.entity_description.key)
+        value = self.coordinator.data.get(self.entity_description.key)
+
+        # converting battery percentage string to integer
+        if (
+            self.entity_description.device_class == SensorDeviceClass.BATTERY
+            and isinstance(value, str)
+            and value.endswith("%")
+        ):
+            try:
+                return int(value[:-1])
+            except ValueError:
+                return None
+
+        return value
 
 
 class IotDeviceSensor(CoordinatorEntity, SensorEntity):


### PR DESCRIPTION
## Summary

This PR fixes battery sensor handling in the Ecowitt integration.

## Changes

- Assigns `device_class: battery` to battery sensors
- Sets unit of measurement to `%`
- Normalizes percentage values (`"100%"` → `100`)
- Uses `native_value` according to Home Assistant sensor API

## Motivation

Some Ecowitt battery sensors are currently exposed as strings with a `%`
suffix and without a battery device class, which prevents numeric
comparisons, automations, and auto-entities filtering.

## Testing

- Home Assistant 2026.2.0.dev0
- Ecowitt GW2000A
- Verified numeric state and battery device class in Developer Tools

## Breaking changes

None.
