### PR TITLE
fix: harden transient-failure handling, fix config flow crash, avoid misleading switch state

### DIFF
--- a/custom_components/ha_ecowitt_iot/config_flow.py
+++ b/custom_components/ha_ecowitt_iot/config_flow.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any
+
 import voluptuous as vol
+from aiohttp.client_exceptions import ClientError
 from wittiot import API
 from wittiot.errors import WittiotError
 
@@ -16,6 +19,8 @@ from homeassistant.helpers import aiohttp_client
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
+
+_CONNECT_ERRORS = (WittiotError, ClientError, asyncio.TimeoutError)
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -33,16 +38,17 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 session=aiohttp_client.async_get_clientsession(self.hass),
             )
 
+            devices: dict[str, Any] | None = None
             try:
                 devices = await api.request_loc_info()
-            except WittiotError:
+            except _CONNECT_ERRORS:
                 errors["base"] = "cannot_connect"
-            _LOGGER.debug("New data received: %s", devices)
+            else:
+                _LOGGER.debug("New data received: %s", devices)
+                if not devices:
+                    errors["base"] = "no_devices"
 
-            if not devices:
-                errors["base"] = "no_devices"
-
-            if not errors:
+            if not errors and devices:
                 unique_id = devices["dev_name"]
                 await self.async_set_unique_id(unique_id)
                 self._abort_if_unique_id_configured()
@@ -58,15 +64,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     @staticmethod
     def async_get_options_flow(config_entry):
         """Get the options flow for this handler."""
-        return OptionsFlowHandler(config_entry)
+        return OptionsFlowHandler()
 
 
 class OptionsFlowHandler(config_entries.OptionsFlow):
     """Handle options flow for Ecowitt integration."""
-
-    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
-        """Initialize options flow."""
-        # self.config_entry = config_entry
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
@@ -83,7 +85,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
 
             try:
                 devices = await api.request_loc_info()
-            except WittiotError:
+            except _CONNECT_ERRORS:
                 errors["base"] = "cannot_connect"
             else:
                 if not devices:

--- a/custom_components/ha_ecowitt_iot/coordinator.py
+++ b/custom_components/ha_ecowitt_iot/coordinator.py
@@ -1,12 +1,13 @@
 """The Ecowitt integration coordinator."""
 from __future__ import annotations
 
-from datetime import timedelta
-import logging
-from typing import Any
 import asyncio
+import logging
 import time
-from aiohttp.client_exceptions import ClientConnectorError
+from datetime import timedelta
+from typing import Any
+
+from aiohttp.client_exceptions import ClientError
 from wittiot import API
 from wittiot.errors import WittiotError
 
@@ -18,10 +19,22 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 from .const import DOMAIN
 
-MAX_CONSECUTIVE_FAILURES = 3
-FIRMWARE_CHECK_INTERVAL_SECONDS = 3600
-
 _LOGGER = logging.getLogger(__name__)
+
+# Transient errors tolerated via the cache-based retry path below.
+_TRANSIENT_ERRORS = (WittiotError, ClientError, asyncio.TimeoutError)
+
+# Per-request timeout. Generous so a busy single-threaded gateway has
+# room to answer; prior code had no timeout and could hang 5 min on a
+# half-dead socket (aiohttp default).
+REQUEST_TIMEOUT_SECONDS = 60
+
+# Number of consecutive failed polls tolerated before raising UpdateFailed.
+# At update_interval=10s this bounds stale-data exposure to ~20s.
+MAX_CONSECUTIVE_FAILURES = 3
+
+# Firmware metadata rarely changes; refresh at most once per hour.
+FIRMWARE_CHECK_INTERVAL_SECONDS = 3600
 
 
 class EcowittDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
@@ -46,43 +59,89 @@ class EcowittDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._last_good_data: dict[str, Any] = {}
         self._firmware_update_info: dict[str, Any] | None = None
         self._last_firmware_check: float = 0.0
+        self._outage_logged = False
 
-    async def _async_update_data(self) -> dict[str, str | float | int]:
-        res: dict[str, Any] = {}
+    async def _async_update_data(self) -> dict[str, Any]:
         try:
-            res = await self.api.request_loc_allinfo()
+            async with asyncio.timeout(REQUEST_TIMEOUT_SECONDS):
+                res: dict[str, Any] = await self.api.request_loc_allinfo()
+        except _TRANSIENT_ERRORS as error:
+            return self._handle_fetch_failure(error)
 
-            now = time.monotonic()
-            if (
-                self._firmware_update_info is None
-                or now - self._last_firmware_check >= FIRMWARE_CHECK_INTERVAL_SECONDS
-            ):
-                firmware_info: dict[str, Any] = await self.api.request_firmware_update_info()
-                try:
-                    check_info: dict[str, Any] = await self.api.request_firmware_update_check()
-                except WittiotError as err:
-                    firmware_info["check_supported"] = False
-                    firmware_info["install_supported"] = False
-                    firmware_info["error"] = str(err)
-                else:
-                    response = check_info.get("response", {})
-                    if isinstance(response, dict):
-                        firmware_info["is_new"] = response.get("is_new", firmware_info.get("is_new", False))
-                        firmware_info["release_summary"] = response.get("msg", firmware_info.get("release_summary"))
-                        firmware_info["check_response"] = response
-                self._firmware_update_info = firmware_info
-                self._last_firmware_check = now
-            res["firmware_update"] = self._firmware_update_info or {}
+        res["firmware_update"] = await self._maybe_update_firmware_info()
 
-        except (WittiotError, ClientConnectorError, asyncio.TimeoutError) as error:
-            self._consecutive_failures += 1
-            if self._consecutive_failures >= MAX_CONSECUTIVE_FAILURES:
-                self._last_good_data = {}
-                raise UpdateFailed(error) from error
-            if self._last_good_data:
-                return self._last_good_data
-            raise UpdateFailed(error) from error
-
+        if self._outage_logged:
+            _LOGGER.info(
+                "Ecowitt gateway %s is reachable again",
+                self.config_entry.data[CONF_HOST],
+            )
+            self._outage_logged = False
         self._consecutive_failures = 0
         self._last_good_data = res
         return res
+
+    def _handle_fetch_failure(self, error: Exception) -> dict[str, Any]:
+        self._consecutive_failures += 1
+        if self._consecutive_failures < MAX_CONSECUTIVE_FAILURES and self._last_good_data:
+            _LOGGER.debug(
+                "Ecowitt fetch failed (%d/%d): %s; serving last known data",
+                self._consecutive_failures,
+                MAX_CONSECUTIVE_FAILURES,
+                error,
+            )
+            return self._last_good_data
+
+        # Tolerance exhausted: drop the cache, log once, and mark unavailable.
+        self._last_good_data = {}
+        if not self._outage_logged:
+            _LOGGER.warning(
+                "Ecowitt gateway %s unreachable for %d consecutive polls (%s); "
+                "entities will be unavailable until it recovers",
+                self.config_entry.data[CONF_HOST],
+                self._consecutive_failures,
+                error,
+            )
+            self._outage_logged = True
+        raise UpdateFailed(
+            f"Gateway unreachable for {self._consecutive_failures} consecutive polls: {error}"
+        ) from error
+
+    async def _maybe_update_firmware_info(self) -> dict[str, Any]:
+        # A firmware endpoint failure must not mask a successful data fetch.
+        now = time.monotonic()
+        if (
+            self._firmware_update_info is not None
+            and now - self._last_firmware_check < FIRMWARE_CHECK_INTERVAL_SECONDS
+        ):
+            return self._firmware_update_info
+
+        try:
+            async with asyncio.timeout(REQUEST_TIMEOUT_SECONDS):
+                firmware_info: dict[str, Any] = await self.api.request_firmware_update_info()
+        except _TRANSIENT_ERRORS as err:
+            _LOGGER.debug(
+                "Firmware info fetch failed; keeping previous metadata: %s", err
+            )
+            return self._firmware_update_info or {}
+
+        try:
+            async with asyncio.timeout(REQUEST_TIMEOUT_SECONDS):
+                check_info: dict[str, Any] = await self.api.request_firmware_update_check()
+        except _TRANSIENT_ERRORS as err:
+            firmware_info["check_supported"] = False
+            firmware_info["install_supported"] = False
+            firmware_info["error"] = str(err)
+        else:
+            response = check_info.get("response", {})
+            if isinstance(response, dict):
+                firmware_info["is_new"] = response.get(
+                    "is_new", firmware_info.get("is_new", False)
+                )
+                firmware_info["release_summary"] = response.get(
+                    "msg", firmware_info.get("release_summary")
+                )
+                firmware_info["check_response"] = response
+
+        self._firmware_update_info = firmware_info
+        self._last_firmware_check = now
+        return firmware_info

--- a/custom_components/ha_ecowitt_iot/sensor.py
+++ b/custom_components/ha_ecowitt_iot/sensor.py
@@ -677,29 +677,22 @@ IOT_SENSOR_DESCRIPTIONS = (
 )
 
 
-def async_remove_old_sub_device(self):
+def async_remove_old_sub_device(hass: HomeAssistant) -> None:
     """删除旧的子设备"""
 
-    # 获取设备注册表
-    device_reg = dr.async_get(self)
+    device_reg = dr.async_get(hass)
 
     prefixes = SubSensorname.prefixes
-    # 通过唯一标识符查找设备
-    # 注意：这里假设你用 unique_id 来匹配设备
-    device = None
     deviceid = []
     for dev in device_reg.devices.values():
         if not dev.identifiers:
-            continue  # 跳过没有标识符的设备
-        # 遍历该设备的所有标识符
+            continue
         for identifier in dev.identifiers:
             if len(identifier) < 2:
-                continue  # 跳过格式不正确的标识符
-            # 假设你的设备标识符元组格式为 (domain, unique_id)
-            if isinstance(identifier[1], (str, list)):  # 确保可迭代
+                continue
+            if isinstance(identifier[1], (str, list)):
                 if [prefix for prefix in prefixes if prefix in identifier[1]]:
-                    device = dev
-                    deviceid.append(device.id)
+                    deviceid.append(dev.id)
 
     for oldsub in deviceid:
         device_reg.async_remove_device(oldsub)

--- a/custom_components/ha_ecowitt_iot/switch.py
+++ b/custom_components/ha_ecowitt_iot/switch.py
@@ -141,9 +141,9 @@ class EcowittSwitch(CoordinatorEntity, SwitchEntity):
                     # self._iot_is_on = item.get("iot_running")
 
     @property
-    def is_on(self) -> bool:
+    def is_on(self) -> bool | None:
         """从协调器获取设备数据."""
-        return self._get_actual_state()  # 如果数据不可用返回None
+        return self._get_actual_state()
 
     async def async_turn_on(self, **kwargs):
         """打开设备."""
@@ -153,20 +153,19 @@ class EcowittSwitch(CoordinatorEntity, SwitchEntity):
         """关闭设备."""
         await self._async_set_state(False)
 
-    def _get_actual_state(self) -> bool:
-        """从协调器获取实际设备状态."""
+    def _get_actual_state(self) -> bool | None:
+        """从协调器获取实际设备状态；找不到或掉线时返回 None 以显示为 unknown/unavailable."""
         if "iot_list" in self.coordinator.data:
             iot_data = self.coordinator.data["iot_list"]
             commands = iot_data["command"]
-            for i, item in enumerate(commands):
+            for item in commands:
                 nickname = item.get("nickname")
                 rfnet_state = item.get("rfnet_state")
                 if rfnet_state == 0:
                     continue
                 if nickname == self.device_id:
-                    # key = self.entity_description.key.split("_", 1)[1]
                     return bool(item.get("iot_running", 0))
-        return False  # 默认返回关状态
+        return None
 
     async def _async_set_state(self, state: bool):
         """设置设备状态（带待处理状态管理）"""


### PR DESCRIPTION
## Summary

Resolves #53 (transient API failures marking all sensors unavailable) with a more robust approach than the original `798255a` patch, and fixes a handful of additional bugs uncovered during review.

The existing `MAX_CONSECUTIVE_FAILURES=3` + `_last_good_data` tolerance from `798255a` is preserved — staleness stays bounded to ~20s at the 10s update interval, which is within acceptable bounds. What this PR adds is everything `798255a` left on the table.

## Changes

### 1. `coordinator.py` — per-request timeout, firmware isolation, broader error catch, outage logging

- **Per-request timeout (60s)** via `asyncio.timeout()`. The previous code had no timeout, so a half-dead socket could block the coordinator for aiohttp's default 5 minutes, effectively killing all updates during the hang.
- **Isolate firmware-check handling** into `_maybe_update_firmware_info()`. Previously, a `WittiotError` from `request_firmware_update_info()` or `request_firmware_update_check()` would be caught by the outer handler and mark the entire poll as failed — even when the main `request_loc_allinfo()` call succeeded. The update entity already gracefully disables itself when `check_supported=False`, so firmware endpoint failures should be swallowed at debug level, never poisoning live sensor data that was fetched successfully.
- **Broaden transient-error tuple** from `(WittiotError, ClientConnectorError, asyncio.TimeoutError)` to `(WittiotError, aiohttp.ClientError, asyncio.TimeoutError)`. `ClientConnectorError` only covered connection setup (DNS, refused); real-world outages also surface as `ServerDisconnectedError`, `ClientOSError`, `ClientPayloadError`, etc., all previously unhandled and propagating as unexpected exceptions.
- **Edge-triggered outage logging.** When retry tolerance is exhausted, log a single `WARNING` with host + consecutive-failure count + underlying error — once per outage, not per cycle. Log a single `INFO` on recovery. Users see exactly why their sensors went unavailable without digging through debug logs, and without log spam during prolonged downtime.
- **Informative `UpdateFailed` message** so HA's own ``Error fetching ... data`` log entry is self-explanatory.

### 2. `config_flow.py` — fix `UnboundLocalError` on connection failure

`async_step_user` referenced `devices` after catching `WittiotError` along a path where `devices` is never assigned. A user entering an unreachable host currently sees a traceback instead of the intended `cannot_connect` form error. Fixed by wrapping result-usage in an `else:` block and gating the create-entry path on `if not errors and devices`.

Also broadens the caught exception tuple to match the coordinator (`WittiotError | ClientError | asyncio.TimeoutError`), so DNS failures and timeouts during setup show `cannot_connect` instead of crashing.

### 3. `config_flow.py` — remove dead `OptionsFlowHandler.__init__`

The existing `__init__` has the `self.config_entry = config_entry` assignment already commented out, which means it already relies on HA ≥ 2024.12's `OptionsFlow` base class auto-populating `self.config_entry`. The override is dead weight — removed, along with the now-unneeded `config_entry` arg in `async_get_options_flow`.

### 4. `switch.py` — return `None` instead of `False` when device is missing

`EcowittSwitch._get_actual_state()` previously returned `False` both for *device is present and off* and *device is missing from `iot_list` / `rfnet_state == 0`*. That silently surfaces a fake ``OFF`` state to HA, which will trigger any automation listening for ``on → off`` transitions even though the device is actually just unreachable. Now returns `None`, rendering as ``unknown`` and leaving automations undisturbed. This also makes `_async_verify_state` more honest: it no longer falsely "confirms" an off state when the device has actually disappeared.

### 5. `sensor.py` — misleading parameter + dead assignment

`async_remove_old_sub_device(self)` is a free function, not a method — the `self` parameter is actually a `HomeAssistant` instance. Renamed to `hass: HomeAssistant` with proper type annotation. Also removed the unused `device = None` / `device = dev` assignments that no code reads.

## Retry audit

Per #53, I audited the retry path end-to-end to confirm the integration cannot end up in a permanent-failure mode:

- **First setup** (`async_config_entry_first_refresh`): wraps `UpdateFailed` in `ConfigEntryNotReady`. HA retries entry setup with exponential backoff (5s → ~15min cap), indefinitely.
- **Runtime**: `DataUpdateCoordinator._async_refresh` catches `UpdateFailed` and any `Exception`, logs, sets `last_update_success=False`, schedules the next call at `update_interval`. No abandonment path.

No coordinator-level retry changes were needed — HA's coordinator already guarantees "retry forever."

Happy to split this PR per-concern if the maintainers prefer atomic changes.

## Test plan

- [ ] Fresh config entry with an offline gateway → setup retries with exponential backoff, no permanent failure.
- [ ] Unplug gateway mid-operation → 2 polls serve cached data, 3rd marks entities unavailable with a single WARNING log.
- [ ] Plug gateway back in → entities become available, single INFO log ``is reachable again``.
- [ ] Firmware endpoint temporarily errors while live data works → live sensors keep updating; firmware entity gracefully disables.
- [ ] Config flow with an unreachable host → form shows ``cannot_connect``, no stacktrace.
- [ ] IoT switch device goes offline (``rfnet_state=0``) → switch becomes ``unknown``, not ``off``.