### PR TITLE
feat: add configurable update_interval

### DIFF
--- a/custom_components/ha_ecowitt_iot/config_flow.py
+++ b/custom_components/ha_ecowitt_iot/config_flow.py
@@ -16,7 +16,7 @@ from homeassistant.const import CONF_HOST
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import aiohttp_client
 
-from .const import CONF_MAC, DOMAIN
+from .const import CONF_MAC, CONF_UPDATE_INTERVAL, DOMAIN, DEFAULT_UPDATE_INTERVAL
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -64,7 +64,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="user",
-            data_schema=vol.Schema({vol.Required(CONF_HOST): str}),
+            data_schema=vol.Schema( {
+                vol.Required(CONF_HOST): str,
+                vol.Required(
+                    CONF_UPDATE_INTERVAL, default=DEFAULT_UPDATE_INTERVAL
+                ): vol.All(int, vol.Range(min=5)),
+            }),
             errors=errors,
         )
 
@@ -136,7 +141,13 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 {
                     vol.Required(
                         CONF_HOST, default=self.config_entry.data.get(CONF_HOST)
-                    ): str
+                    ): str,
+                    vol.Required(
+                        CONF_UPDATE_INTERVAL,
+                        default=self.config_entry.data.get(
+                            CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL
+                        ),
+                    ): vol.All(int, vol.Range(min=5)),
                 }
             ),
             errors=errors,

--- a/custom_components/ha_ecowitt_iot/const.py
+++ b/custom_components/ha_ecowitt_iot/const.py
@@ -4,3 +4,5 @@ DOMAIN = "ha_ecowitt_iot"
 CONF_VERSION = 2
 
 CONF_MAC = "mac"
+CONF_UPDATE_INTERVAL = "update_interval"
+DEFAULT_UPDATE_INTERVAL = 10

--- a/custom_components/ha_ecowitt_iot/coordinator.py
+++ b/custom_components/ha_ecowitt_iot/coordinator.py
@@ -18,7 +18,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.helpers.translation import async_get_translations
 
-from .const import CONF_MAC, DOMAIN
+from .const import CONF_MAC, DOMAIN, CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -58,8 +58,9 @@ class EcowittDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         config_entry: ConfigEntry,
     ) -> None:
         """Initialize."""
+        update_interval = config_entry.data.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL)
         super().__init__(
-            hass, _LOGGER, name=DOMAIN, update_interval=timedelta(seconds=10)
+            hass, _LOGGER, name=DOMAIN, update_interval=timedelta(seconds=update_interval)
         )
         self.config_entry = config_entry
         self.api = API(

--- a/custom_components/ha_ecowitt_iot/strings.json
+++ b/custom_components/ha_ecowitt_iot/strings.json
@@ -3,10 +3,12 @@
     "step": {
       "user": {
         "data": {
-          "host": "[%key:common::config_flow::data::host%]"
+          "host": "[%key:common::config_flow::data::host%]",
+          "update_interval": "Update interval"
         },
         "data_description": {
-          "host": "The IP address of the device."
+          "host": "The IP address of the device.",
+          "update_interval": "How often the device is polled for new data (in seconds, minimum 5)."
         }
       }
     },
@@ -30,7 +32,11 @@
         "title": "Configure",
         "description": "Update the settings for your Ecowitt device",
         "data": {
-          "host": "Device IP address"
+          "host": "Device IP address",
+          "update_interval": "Update interval"
+        },
+        "data_description": {
+          "update_interval": "How often the device is polled for new data (in seconds, minimum 5)."
         }
       }
     }

--- a/custom_components/ha_ecowitt_iot/translations/de.json
+++ b/custom_components/ha_ecowitt_iot/translations/de.json
@@ -11,7 +11,11 @@
         "step": {
             "user": {
                 "data": {
-                    "host": "IP Adresse Gerät"
+                    "host": "IP Adresse Gerät",
+                    "update_interval": "Aktualisierungsintervall"
+                },
+                "data_description": {
+                    "update_interval": "Wie oft das Gerät nach neuen Daten abgefragt wird (in Sekunden, Minimum 5)."
                 },
                 "description": "Bitte geben Sie die IP-Adresse des Gerätes an zum Darstellen der Daten",
                 "title": "Gerät Konfiguration"
@@ -29,7 +33,11 @@
                 "title": "Gerät Konfiguration",
                 "description": "Bitte geben Sie die IP-Adresse des Gerätes an zum Darstellen der Daten",
                 "data": {
-                    "host": "IP Adresse Gerät"
+                    "host": "IP Adresse Gerät",
+                    "update_interval": "Aktualisierungsintervall"
+                },
+                "data_description": {
+                    "update_interval": "Wie oft das Gerät nach neuen Daten abgefragt wird (in Sekunden, Minimum 5)."
                 }
             }
         }

--- a/custom_components/ha_ecowitt_iot/translations/en.json
+++ b/custom_components/ha_ecowitt_iot/translations/en.json
@@ -11,7 +11,11 @@
         "step": {
             "user": {
                 "data": {
-                    "host": "Device IP address"
+                    "host": "Device IP address",
+                    "update_interval": "Update interval"
+                },
+                "data_description": {
+                    "update_interval": "How often the device is polled for new data (in seconds, minimum 5)."
                 },
                 "description": "Please enter the IP address of the device to view the data",
                 "title": "Device configuration"
@@ -29,7 +33,11 @@
                 "title": "Configure",
                 "description": "Update the settings for your Ecowitt device",
                 "data": {
-                    "host": "Device IP address"
+                    "host": "Device IP address",
+                    "update_interval": "Update interval"
+                },
+                "data_description": {
+                    "update_interval": "How often the device is polled for new data (in seconds, minimum 5)."
                 }
             }
         }

--- a/custom_components/ha_ecowitt_iot/translations/fr.json
+++ b/custom_components/ha_ecowitt_iot/translations/fr.json
@@ -11,7 +11,11 @@
         "step": {
             "user": {
                 "data": {
-                    "host": "Adresse IP de l'appareil"
+                    "host": "Adresse IP de l'appareil",
+                    "update_interval": "Intervalle de mise à jour"
+                },
+                "data_description": {
+                    "update_interval": "Fréquence d'interrogation de l'appareil (en secondes, minimum 5)."
                 },
                 "description": "Merci de saisir l'adresse IP de l'appareil afin de consulter ses données",
                 "title": "Configuration de l'appareil"
@@ -29,7 +33,11 @@
                 "title": "Configurer",
                 "description": "Mettre à jour les réglages de votre appareil Ecowitt",
                 "data": {
-                    "host": "Adresse IP de l'appareil"
+                    "host": "Adresse IP de l'appareil",
+                    "update_interval": "Intervalle de mise à jour"
+                },
+                "data_description": {
+                    "update_interval": "Fréquence d'interrogation de l'appareil (en secondes, minimum 5)."
                 }
             }
         }


### PR DESCRIPTION
## Add `update_interval` 
### Changes

- Added one new parameter to the config flow (initial setup) and options flow (reconfiguration):
  - **`update_interval`** *(int, default: 10s, min: 5s)* — controls how often the coordinator polls the device
- The coordinator now reads `update_interval` from the config entry instead of using a hardcoded 10s value
- Translation files updated accordingly: `en.json`, `fr.json`, `de.json`

Feedback welcome on this before merging.