### PR TITLE
Fix sensor metadata: wind direction device class, state classes, display precision

### DIFF
--- a/custom_components/ha_ecowitt_iot/sensor.py
+++ b/custom_components/ha_ecowitt_iot/sensor.py
@@ -142,14 +142,14 @@ SENSOR_DESCRIPTIONS = (
         key="baromrelin",
         translation_key="baromrelin",
         native_unit_of_measurement=UnitOfPressure.INHG,
-        device_class=SensorDeviceClass.PRESSURE,
+        device_class=SensorDeviceClass.ATMOSPHERIC_PRESSURE,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(
         key="baromabsin",
         translation_key="baromabsin",
         native_unit_of_measurement=UnitOfPressure.INHG,
-        device_class=SensorDeviceClass.PRESSURE,
+        device_class=SensorDeviceClass.ATMOSPHERIC_PRESSURE,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(
@@ -157,18 +157,21 @@ SENSOR_DESCRIPTIONS = (
         translation_key="vpd",
         native_unit_of_measurement=UnitOfPressure.INHG,
         device_class=SensorDeviceClass.PRESSURE,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(
         key="winddir",
         translation_key="winddir",
-        icon="mdi:weather-windy",
         native_unit_of_measurement=DEGREE,
+        device_class=SensorDeviceClass.WIND_DIRECTION,
+        state_class=SensorStateClass.MEASUREMENT_ANGLE,
     ),
     SensorEntityDescription(
         key="winddir10",
         translation_key="winddir10",
-        icon="mdi:weather-windy",
         native_unit_of_measurement=DEGREE,
+        device_class=SensorDeviceClass.WIND_DIRECTION,
+        state_class=SensorStateClass.MEASUREMENT_ANGLE,
     ),
     SensorEntityDescription(
         key="windspeedmph",
@@ -176,6 +179,7 @@ SENSOR_DESCRIPTIONS = (
         device_class=SensorDeviceClass.WIND_SPEED,
         native_unit_of_measurement=UnitOfSpeed.MILES_PER_HOUR,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
     ),
     SensorEntityDescription(
         key="windgustmph",
@@ -183,6 +187,7 @@ SENSOR_DESCRIPTIONS = (
         device_class=SensorDeviceClass.WIND_SPEED,
         native_unit_of_measurement=UnitOfSpeed.MILES_PER_HOUR,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
     ),
     SensorEntityDescription(
         key="daywindmax",
@@ -190,6 +195,7 @@ SENSOR_DESCRIPTIONS = (
         device_class=SensorDeviceClass.WIND_SPEED,
         native_unit_of_measurement=UnitOfSpeed.MILES_PER_HOUR,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
     ),
     SensorEntityDescription(
         key="uv",
@@ -265,7 +271,7 @@ SENSOR_DESCRIPTIONS = (
         translation_key="24hrainin",
         device_class=SensorDeviceClass.PRECIPITATION,
         native_unit_of_measurement=UnitOfPrecipitationDepth.INCHES,
-        state_class=SensorStateClass.TOTAL_INCREASING,
+        state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=2,
     ),
     SensorEntityDescription(
@@ -409,7 +415,7 @@ SENSOR_DESCRIPTIONS = (
         key="pm4_24h_co2_add",
         translation_key="pm4_24h_co2_add",
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-        device_class=SensorDeviceClass.PM25,
+        device_class=SensorDeviceClass.PM4,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(
@@ -508,7 +514,7 @@ SENSOR_DESCRIPTIONS = (
         key="pm4_co2",
         translation_key="pm4_co2",
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-        device_class=SensorDeviceClass.PM25,
+        device_class=SensorDeviceClass.PM4,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(
@@ -599,8 +605,8 @@ ECOWITT_SENSORS_MAPPING: Final = {
         key="RSSI",
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+        device_class=SensorDeviceClass.SIGNAL_STRENGTH,
         entity_category=EntityCategory.DIAGNOSTIC,
-        icon="mdi:wifi",
     ),
 }
 # 定义 IoT 设备的传感器描述
@@ -652,18 +658,21 @@ IOT_SENSOR_DESCRIPTIONS = (
         translation_key="wfc02_flow_velocity",
         native_unit_of_measurement=UnitOfVolumeFlowRate.LITERS_PER_MINUTE,
         device_class=SensorDeviceClass.VOLUME_FLOW_RATE,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(
         key="velocity_total",
         translation_key="velocity_total",
         native_unit_of_measurement=UnitOfVolume.LITERS,
         device_class=SensorDeviceClass.WATER,
+        state_class=SensorStateClass.TOTAL_INCREASING,
     ),
     SensorEntityDescription(
         key="flow_velocity",
         translation_key="flow_velocity",
         native_unit_of_measurement=UnitOfVolumeFlowRate.LITERS_PER_MINUTE,
         device_class=SensorDeviceClass.VOLUME_FLOW_RATE,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(
         key="data_water_t",
@@ -677,6 +686,7 @@ IOT_SENSOR_DESCRIPTIONS = (
         translation_key="data_ac_v",
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(
         key="elect_total",
@@ -690,6 +700,7 @@ IOT_SENSOR_DESCRIPTIONS = (
         translation_key="realtime_power",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
 )
 


### PR DESCRIPTION
Fixes #81.

Corrects sensor entity metadata across `sensor.py`:

**Incorrect classifications**
- `winddir` / `winddir10`: add `device_class=WIND_DIRECTION` + `state_class=MEASUREMENT_ANGLE`, drop the hardcoded `mdi:weather-windy` icon. This enables the frontend's rotating direction arrow (the hardcoded icon overrides it) and correct circular statistics — plain mean/min/max is meaningless for a 0–360° wrap-around value.
- `24hrainin`: `TOTAL_INCREASING` → `MEASUREMENT`. A rolling 24 h total decreases as old rain ages out, so `TOTAL_INCREASING` records phantom meter-resets; `24hrain_piezo` already uses `MEASUREMENT`.
- `pm4_co2` / `pm4_24h_co2_add`: `PM25` → `PM4` device class.
- RSSI mapping in `ECOWITT_SENSORS_MAPPING`: add `device_class=SIGNAL_STRENGTH`, drop the hardcoded icon (frontend derives it).
- `baromrelin` / `baromabsin`: `PRESSURE` → `ATMOSPHERIC_PRESSURE` (matches HA core's `ecowitt` integration).

**Missing `state_class` (no long-term statistics recorded)**
- `vpd`, `realtime_power`, `data_ac_v`, `flow_velocity`, `wfc02_flow_velocity`: add `MEASUREMENT`.
- `velocity_total`: add `TOTAL_INCREASING` — makes the WFC02 water meter selectable in the Energy dashboard's water tracking.

**Display**
- `windspeedmph` / `windgustmph` / `daywindmax`: `suggested_display_precision=1`. Metric users otherwise get mph→km/h conversion at 2 decimals, which is false precision for these sensors.

Notes for reviewers: metadata-only change, no runtime logic touched. `MEASUREMENT_ANGLE`, `SensorDeviceClass.PM4` and `WIND_DIRECTION` require a recent HA core; existing `winddir`/`24hrainin` long-term statistics will raise a one-time statistics repair prompt in HA due to the state_class change, which is expected.